### PR TITLE
Single precision

### DIFF
--- a/lib/arithmetic_sse_float.h
+++ b/lib/arithmetic_sse_float.h
@@ -65,7 +65,11 @@ inline static void* vecalloc(size_t size)
 
 inline static void vecfree(void *memblock)
 {
+#ifdef	_MSC_VER
     _aligned_free(memblock);
+#else
+    free(memblock);
+#endif
 }
 
 #define vecset(x, c, n) \


### PR DESCRIPTION
I couldn't compile the library with single precision ("-DLBFGS_FLOAT32"). This fixed it for me.
