### PR TITLE
Add .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,69 @@
+## C
+
+# Object files
+*.o
+*.lo
+*.la
+
+# Libraries
+*.lib
+*.a
+
+# Shared objects (inc. Windows DLLs)
+*.dll
+*.so
+*.so.*
+*.dylib
+
+# Executables
+*.exe
+*.out
+*.app
+
+
+## Autotools
+
+# http://www.gnu.org/software/automake
+
+Makefile.in
+
+# http://www.gnu.org/software/autoconf
+
+/autom4te.cache
+/aclocal.m4
+/compile
+/configure
+/depcomp
+/install-sh
+/missing
+
+
+## vim
+
+.*.s[a-w][a-z]
+*.un~
+Session.vim
+.netrwhist
+*~
+
+## liblbfgs-specific 
+INSTALL
+Makefile
+config.guess
+config.h
+config.h.in
+config.log
+config.status
+config.sub
+lib/.deps
+lib/.libs
+lib/Makefile
+libtool
+ltmain.sh
+sample/.deps
+sample/.libs
+sample/sample
+sample/Makefile
+stamp-h1
+
+


### PR DESCRIPTION
Hi chokkan,

thanks for your amazing library! I'm using liblbfgs as a git submodule in my own MRF-learning project. Everytime I compile liblbfgs, the various files created by the compilation process show up as uncommitted changes in the liblbfgs tree and ergo in my main project. 

This gitignore file, which is a combination of the gitignore boilerplates at github/gitignore for C, autotools, vim and some liblbfgs-specific stuff, should make this more comfortable.

Best,
Stefan
