### PR TITLE
Fix compilation failure (with --enable-sse2) on recent Linux systems.

### DIFF
--- a/configure.in
+++ b/configure.in
@@ -42,14 +42,6 @@ INCLUDES="-I\$(top_srcdir) -I\$(top_srcdir)/include"
 
 
 dnl ------------------------------------------------------------------
-dnl Checks for header files.
-dnl ------------------------------------------------------------------
-AC_HEADER_STDC
-AC_CHECK_HEADERS(xmmintrin.h emmintrin.h)
-
-
-
-dnl ------------------------------------------------------------------
 dnl Checks for debugging mode
 dnl ------------------------------------------------------------------
 AC_ARG_ENABLE(
@@ -85,6 +77,14 @@ AC_ARG_ENABLE(
         )],
     [CFLAGS="-msse2 -DUSE_SSE ${CFLAGS}"]
 )
+
+dnl ------------------------------------------------------------------
+dnl Checks for header files.
+dnl ------------------------------------------------------------------
+AC_HEADER_STDC
+AC_CHECK_HEADERS(xmmintrin.h emmintrin.h)
+
+
 
 dnl ------------------------------------------------------------------
 dnl Checks for library functions.


### PR DESCRIPTION
We have to add -msse2 to CFLAGS before checking
for xmmintrin.h and emmintrin.h headers.
