### PR TITLE
posix_memalign not defined with mingw

### DIFF
--- a/lib/arithmetic_sse_double.h
+++ b/lib/arithmetic_sse_double.h
@@ -41,7 +41,7 @@
 
 inline static void* vecalloc(size_t size)
 {
-#if     defined(_MSC_VER)
+#if     defined(_WIN32)
     void *memblock = _aligned_malloc(size, 16);
 #elif   defined(__APPLE__)  /* OS X always aligns on 16-byte boundaries */
     void *memblock = malloc(size);


### PR DESCRIPTION
using the _WIN32 macro catches both on MSVC and mingw