### PR TITLE
Make lbfgs() to return LBFGSERR_CANCELED when callback function returns non-zero value

### DIFF
--- a/lib/lbfgs.c
+++ b/lib/lbfgs.c
@@ -494,7 +494,8 @@ int lbfgs(
 
         /* Report the progress. */
         if (cd.proc_progress) {
-            if ((ret = cd.proc_progress(cd.instance, x, g, fx, xnorm, gnorm, step, cd.n, k, ls))) {
+            if (cd.proc_progress(cd.instance, x, g, fx, xnorm, gnorm, step, cd.n, k, ls)) {
+                ret = LBFGSERR_CANCELED;
                 goto lbfgs_exit;
             }
         }


### PR DESCRIPTION
The second option to resolve #36
